### PR TITLE
some models for dbt-impala-example are not appearing in Hue when adapted to run with dbt-spark-livy adapter

### DIFF
--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -191,8 +191,8 @@ class LivyCursor:
                 # print("rows", self._rows)
                 # print("schema", self._schema)
             else:
-                self._rows = None
-                self._schema = None
+                self._rows = []
+                self._schema = []
         else:
             self._rows = None
             self._schema = None 


### PR DESCRIPTION


Internal Ticket: https://jira.cloudera.com/projects/DBT/issues/DBT-124

Synopsis: When debug the the ticket, the dbt logs indicated that there was an error in list_relations_without_caching indicating a NoneType was passed to the macro.
This PR is a probable fix for the issue.


