### PR TITLE
Revert "some models for dbt-impala-example are not appearing in Hue when adapted to run with dbt-spark-livy adapter"

### DIFF
--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -191,8 +191,8 @@ class LivyCursor:
                 # print("rows", self._rows)
                 # print("schema", self._schema)
             else:
-                self._rows = []
-                self._schema = []
+                self._rows = None
+                self._schema = None
         else:
             self._rows = None
             self._schema = None 


### PR DESCRIPTION
Reverts cloudera/dbt-spark-livy#6