### PR TITLE
some models for dbt-impala-example are not appearing in Hue when adapted to run with dbt-spark-livy adapter

### DIFF
--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -180,8 +180,6 @@ class LivyCursor:
 
         res = self._getLivyResult(self._submitLivyCode(self._getLivySQL(sql)))
         
-        # print(res)
-        
         if (res['output']['status'] == 'ok'):
             # values = res['output']['data']['application/json']
             values = res['output']['data']['application/json']
@@ -191,11 +189,15 @@ class LivyCursor:
                 # print("rows", self._rows)
                 # print("schema", self._schema)
             else:
-                self._rows = None
-                self._schema = None
+                self._rows = []
+                self._schema = []
         else:
             self._rows = None
-            self._schema = None 
+            self._schema = None
+
+            raise dbt.exceptions.raise_database_error(
+                        'Error while executing query: ' + res['output']['evalue']
+                    ) 
 
     def fetchall(self):
         """


### PR DESCRIPTION
Internal Ticket: https://jira.cloudera.com/projects/DBT/issues/DBT-124

Synopsis: When debugging the above ticket, the dbt logs indicated that there was an error in list_relations_without_caching indicating a NoneType was passed to the macro.
Further it was observed that when an actual error by SQL executing in the warehouse was thrown, the error was silently ignored.
This PR addresses this issue.

Testplan:
Clone and successfully execute dbt seed and dbt run for the project https://github.com/TapasSenapati/dbt-spark-example

