### PR TITLE
add usage tracking to spark_livy adapter

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,5 @@
+# modify and copy this file to dbt/adapters/spark_livy/.env
+SNOWPLOW_ENDPOINT=[https://events-end-point-url.com/events]
+SNOWPLOW_TIMEOUT=10
+SNOWPLOW_API_KEY=[xyzSECRECT_KEYxyz]
+SNOWPLOW_ENNV=prod

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ test.env
 .spark-warehouse/
 dbt-integration-tests
 test/integration/.user.yml
+
+.env

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include dbt/include *.sql *.yml *.md
+recursive-include dbt/adapter *.env

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,15 @@ setup(
     long_description_content_type="text/markdown",
     author="Cloudera",
     author_email="innovation-feedback@cloudera.com",
-    url="https://github.com/cloudera/dbt-impala",
+    url="https://github.com/cloudera/dbt-spark-livy",
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
+    data_files=[('', ['dbt/adapters/spark_livy/.env'])],
     include_package_data=True,
     install_requires=[
         "dbt-core>=1.1.0",
         "pyspark",
-        "sqlparams"
+        "sqlparams",
+        "python-decouple>=3.6"
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
add usage tracking (Cloudera specific) to spark_livy adapter

Internal Ticket: https://jira.cloudera.com/browse/DBT-126

Testplan:
- copy .env_example to dbt/adapters/spark_livy/.env
- edit dbt/adapters/spark_livy/.env and change SNOWPLOW_ENDPOINT and SNOWPLOW_API_KEY to appropriate values
- run dbt debug
- check if instrumentation data is being recoded, see ticket internal ticket (https://jira.cloudera.com/browse/DBT-68)
- Build and tested with the following settings of .env_example
SNOWPLOW_ENDPOINT=https://dcevents.cldrteam.datacoral.io/cldrteam/apievents
SNOWPLOW_TIMEOUT=10
SNOWPLOW_API_KEY=-ProductionKey-
SNOWPLOW_ENNV=prod

