### PR TITLE
Add http error identification for credentials and hostname errors

### DIFF
--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -290,6 +290,7 @@ class LivyConnectionManager:
         }
 
         # Create sessions
+        response = None
         try:
             response = requests.post(connect_url + '/sessions', data=json.dumps(data), headers=headers, auth=auth)
             response.raise_for_status()
@@ -305,7 +306,11 @@ class LivyConnectionManager:
         if response is None:
             raise Exception("Invalid response from livy server")
 
-        session_id = str(response.json()['id'])
+        session_id = None
+        try:
+            session_id = str(response.json()['id'])
+        except requests.exceptions.JSONDecodeError as json_err:
+            raise Exception("Json decode error to get session_id") from json_err
 
         # Wait for started state
         while True:

--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import time 
 import requests
+from urllib import response
 
 import datetime as dt
 from types import TracebackType
@@ -289,7 +290,22 @@ class LivyConnectionManager:
         }
 
         # Create sessions
-        session_id = str(requests.post(connect_url + '/sessions', data=json.dumps(data), headers=headers, auth=auth).json()['id'])
+        try:
+            response = requests.post(connect_url + '/sessions', data=json.dumps(data), headers=headers, auth=auth)
+            response.raise_for_status()
+        except requests.exceptions.ConnectionError as c_err:
+            print("Connection Error :", c_err)
+        except requests.exceptions.HTTPError as h_err:
+            print("Http Error: ", h_err)
+        except requests.exceptions.Timeout as t_err:
+            print("Timeout Error: ", t_err)
+        except requests.exceptions.RequestException as a_err:
+            print("Authorization Error: ", a_err)
+
+        if response is None:
+            raise Exception("Invalid response from livy server")
+
+        session_id = str(response.json()['id'])
 
         # Wait for started state
         while True:


### PR DESCRIPTION
Internal ticket: https://jira.cloudera.com/browse/DBT-326

The error printed seems to be generic, so adding
code to identity the type request failure from Livy server.

Test plan:
  * Move into a dbt spark livy project
  * Install dbt-spark-livy from this git repo
  * Add profile details in your home dbt file like from thi page https://community.cloudera.com/t5/Innovation-Blog/Getting-started-with-dbt-spark-livy-adapter/ba-p/347360
  * Update with wrong hostname or wrong user credentials
  * run > dbt debug, and you should see the type of error in the console
  * Add below snowplow configs to your .env if you face any snowplow error SNOWPLOW_ENDPOINT=https://dcevents.cldrteam.datacoral.io/cldrteam/apievents SNOWPLOW_TIMEOUT=10 SNOWPLOW_API_KEY=P8TkX3zUwtOIxJkoKngn3Rf9j3jyro6Bfnd50AEV SNOWPLOW_ENNV=prod

Signed-off-by: Sanjeev kumar N <sanjeevitcit@gmail.com>