### PR TITLE
Update livy connection method to pass spark parameters to Livy server

### DIFF
--- a/dbt/adapters/spark_livy/connections.py
+++ b/dbt/adapters/spark_livy/connections.py
@@ -87,6 +87,7 @@ class SparkCredentials(Credentials):
     retry_all: bool = False
     password: Optional[str] = None
     usage_tracking: Optional[bool] = True
+    livy_session_parameters: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def __pre_deserialize__(cls, data):
@@ -455,7 +456,7 @@ class SparkConnectionManager(SQLConnectionManager):
                     handle = SessionConnectionWrapper(Connection())
                 elif creds.method == SparkConnectionMethod.LIVY:
                     # connect to livy interactive session
-                    handle = LivySessionConnectionWrapper(LivyConnectionManager().connect(creds.host, creds.user, creds.password))
+                    handle = LivySessionConnectionWrapper(LivyConnectionManager().connect(creds.host, creds.user, creds.password, creds.livy_session_parameters))
 
                     try:
                         if (creds.usage_tracking):

--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -246,11 +246,12 @@ class LivyConnection:
     https://github.com/mkleehammer/pyodbc/wiki/Connection
     """
 
-    def __init__(self, connect_url, session_id, auth, headers) -> None:
+    def __init__(self, connect_url, session_id, auth, headers, session_params) -> None:
         self.connect_url = connect_url
         self.session_id = session_id
         self.auth = auth
         self.headers = headers
+        self.session_params = session_params
 
     def get_session_id(self):
         return self.session_id
@@ -277,12 +278,13 @@ class LivyConnection:
 
 class LivyConnectionManager:
     
-    def connect(self, connect_url, user, password):
+    def connect(self, connect_url, user, password, session_params):
         auth = requests.auth.HTTPBasicAuth(user, password)
 
         # the following opens an spark / sql session
         data = {
-            'kind': 'sql' # 'spark'
+            'kind': 'sql', # 'spark'
+            'conf': session_params
         }
 
         headers = {
@@ -326,7 +328,7 @@ class LivyConnectionManager:
 
             time.sleep(DEFAULT_POLL_WAIT)
 
-        livyConnection = LivyConnection(connect_url, session_id, auth, headers)
+        livyConnection = LivyConnection(connect_url, session_id, auth, headers, session_params)
 
         return livyConnection
 


### PR DESCRIPTION
Internal ticket: https://jira.cloudera.com/browse/DBT-357

Test plan:
  * Move into a dbt spark livy project
  * Install dbt-spark-livy from this git repo
  * Update your ~/.dbt/profiles.yml with some spark parameters like below 
  dbt_spark_livy_demo:
  outputs:
    dev:
      type: spark_livy
      method: livy
      schema: dbt_spark_livy_demo
      dbname: dbt_spark_livy_demo
      host: {}
      threads: 2
      user: {}
      password: {}
      livy_session_parameters:
        spark.kryo.unsafe: false
        spark.shuffle.push.enabled: false
        spark.shuffle.push.finalize.timeout: 12s
        spark.hadoop.fs.s3a.acl.default: BucketOwnerFullControl
  target: dev
  * run > dbt debug, once this is successful, check your spark server history app for the specific session and you can see the passed parameters

Signed-off-by: Sanjeev kumar N <sanjeevitcit@gmail.com>