### PR TITLE
[DBT-456] Add code to fetching warehouse version

### DIFF
--- a/dbt/adapters/spark_livy/impl.py
+++ b/dbt/adapters/spark_livy/impl.py
@@ -1,7 +1,8 @@
 import re
+import json
 from concurrent.futures import Future
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union, OrderedDict
 from typing_extensions import TypeAlias
 
 import agate
@@ -16,6 +17,7 @@ from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.spark_livy import SparkConnectionManager
 from dbt.adapters.spark_livy import SparkRelation
 from dbt.adapters.spark_livy import SparkColumn
+import dbt.adapters.spark_livy.cloudera_tracking as tracker
 from dbt.adapters.base import BaseRelation
 from dbt.clients.agate_helper import DEFAULT_TYPE_TESTER
 from dbt.events import AdapterLogger
@@ -376,6 +378,39 @@ class SparkAdapter(SQLAdapter):
             raise
         finally:
             conn.transaction_open = False
+
+    def debug_query(self) -> None:
+        self.execute("select 1 as id")
+
+        # query warehouse version
+        try:
+            sql_query = "select version()"
+            _, table = self.execute(sql_query, True, True)
+            version_object = []
+            json_funcs = [c.jsonify for c in table.column_types]
+
+            for row in table.rows:
+                values = tuple(json_funcs[i](d) for i, d in enumerate(row))
+                version_object.append(OrderedDict(zip(row.keys(), values)))
+
+            version_json = json.dumps(version_object)
+
+            payload = {
+                "event_type": "dbt_spark_livy_warehouse",
+                "warehouse_version": version_json,
+            }
+            tracker.track_usage(payload)
+        except Exception as ex:
+            logger.error(
+                f"Failed to fetch warehouse version. Exception: {ex}"
+            )
+            payload = {
+                "event_type": "dbt_spark_livy_warehouse",
+                "warehouse_version": "NA",
+            }
+            tracker.track_usage(payload)
+
+        self.connections.get_thread_connection().handle.close()
 
 
 # spark does something interesting with joins when both tables have the same

--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -139,7 +139,7 @@ class LivyCursor:
         # code = "val sprk_sql = spark.sql(\"" + escapedSQL + "\")\nval sprk_res=sprk_sql.collect\n%json sprk_res"  # .format(escapedSQL)
 
         # TODO: since the above code is not changed to sending direct SQL to the livy backend, client side string escaping is probably not needed
-        code = sql
+        code = sql.replace("\n", " ").replace("\t", " ")
 
         # print(code)
 

--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -139,7 +139,7 @@ class LivyCursor:
         # code = "val sprk_sql = spark.sql(\"" + escapedSQL + "\")\nval sprk_res=sprk_sql.collect\n%json sprk_res"  # .format(escapedSQL)
 
         # TODO: since the above code is not changed to sending direct SQL to the livy backend, client side string escaping is probably not needed
-        code = sql.replace("\n", " ").replace("\t", " ")
+        code = sql
 
         # print(code)
 


### PR DESCRIPTION
## Describe your changes
Fetch warehouse version when available, and send it along the instrumentation data.
Only supported for Spark 3 and above

## Internal Jira ticket number or external issue link
DBT-456 (internal)

## Testing procedure/screenshots(if appropriate):
For a valid dbt profile, run dbt debug, the logs should produce an instrumentation record similar to the following:

10:27:21.132604 [debug] [Thread-6  ]: Tracker adapter: Sending Event [{"data": {"event_type": "dbt_spark_livy_warehouse", "warehouse_version": "[{\"version()\": \"3.2.1 f38f605165f50b0d9e887e279c350728b839915d\"}]", "auth": "N/A", "connection_state": "N/A", "elapsed_time": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "dff525d4-219b-46cd-b58a-f5ceee395564", "unique_host_hash": "279763963ad1afa5776991f84894d563", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "ec5d62227c01b174fb67e6caf1dd6fe9", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.1.2", "dbt_adapter": "spark_livy-1.1.5", "ml_runtime_edition": "", "ml_runtime_git_hash": "", "ml_runtime_kernel": "", "ml_runtime_editor": "", "ml_runtime_gbn": "", "ml_runtime_full_version": "", "ml_runtime_description": "", "ml_runtime_maintenance_version": "", "ml_runtime_metadata_version": ""}}]

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have formatted my added/modified code to follow pep-8 standards
- [X] I have checked suggestions from python linter to make sure code is of good quality.