### PR TITLE
[DBT-529] add profile variable to switch on/off ssl certificate verification

### DIFF
--- a/dbt/adapters/spark_livy/connections.py
+++ b/dbt/adapters/spark_livy/connections.py
@@ -90,6 +90,7 @@ class SparkCredentials(Credentials):
     password: Optional[str] = None
     usage_tracking: Optional[bool] = True
     livy_session_parameters: Dict[str, Any] = field(default_factory=dict)
+    verify_ssl_certificate: Optional[bool] = True
 
     @classmethod
     def __pre_deserialize__(cls, data):
@@ -479,7 +480,8 @@ class SparkConnectionManager(SQLConnectionManager):
                                 creds.user,
                                 creds.password,
                                 creds.auth,
-                                creds.livy_session_parameters
+                                creds.livy_session_parameters,
+                                creds.verify_ssl_certificate
                             )
                         )
                         connection_end_time = time.time()


### PR DESCRIPTION
## Describe your changes
Add an optional profile flag verify_ssl_certificate allowing to switch on/off ssl certificate verification.
Default value of this flag in True, meaning ssl certificate will be verified by default.

## Internal Jira ticket number or external issue link
DBT-529 (Internal)

## Testing procedure/screenshots(if appropriate):
In a valid dbt-spark-livy profile, add: verify_ssl_certificate: false (to disable ssl certificate verification, default value being true), the dbt debug should succeed. 

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have checked suggestions from python linter to make sure code is of good quality.