### PR TITLE
reuse livy session for a dbt run session

### DIFF
--- a/dbt/adapters/spark_livy/connections.py
+++ b/dbt/adapters/spark_livy/connections.py
@@ -304,7 +304,7 @@ class SparkConnectionManager(SQLConnectionManager):
     SPARK_SQL_ENDPOINT_HTTP_PATH = "/sql/1.0/endpoints/{endpoint}"
     SPARK_CONNECTION_URL = "{host}:{port}" + SPARK_CLUSTER_HTTP_PATH
 
-    connection_manager = None
+    connection_managers = {}
 
     def __init__(self, profile: AdapterRequiredConfig):
         super().__init__(profile)
@@ -482,11 +482,13 @@ class SparkConnectionManager(SQLConnectionManager):
                     connection_start_time = time.time()
                     connection_ex = None
                     try:
-                        if not SparkConnectionManager.connection_manager:
-                             SparkConnectionManager.connection_manager = LivyConnectionManager()
+                        thread_id = cls.get_thread_identifier() 
+
+                        if not thread_id in SparkConnectionManager.connection_managers:
+                             SparkConnectionManager.connection_managers[thread_id] = LivyConnectionManager()
 
                         handle = LivySessionConnectionWrapper(
-                             SparkConnectionManager.connection_manager.connect(
+                             SparkConnectionManager.connection_managers[thread_id].connect(
                                                              creds.host,
                                                              creds.user,
                                                              creds.password,

--- a/dbt/adapters/spark_livy/impl.py
+++ b/dbt/adapters/spark_livy/impl.py
@@ -442,8 +442,12 @@ class SparkAdapter(SQLAdapter):
         self.connections.cleanup_all()
         logger.debug("cleanup_connections")
 
+        # close all sessions
         for conn_mgr in SparkConnectionManager.connection_managers:
             SparkConnectionManager.connection_managers[conn_mgr].livy_global_session.delete_session()
+
+        # reset connection_manager list
+        SparkConnectionManager.connection_managers = {}
 
 # spark does something interesting with joins when both tables have the same
 # static values for the join condition and complains that the join condition is

--- a/dbt/adapters/spark_livy/impl.py
+++ b/dbt/adapters/spark_livy/impl.py
@@ -438,6 +438,10 @@ class SparkAdapter(SQLAdapter):
 
         self.connections.get_thread_connection().handle.close()
 
+    def cleanup_connections(self) -> None:
+        self.connections.cleanup_all()
+        logger.debug("cleanup_connections")
+        SparkConnectionManager.connection_manager.livy_global_session.delete_session()
 
 # spark does something interesting with joins when both tables have the same
 # static values for the join condition and complains that the join condition is

--- a/dbt/adapters/spark_livy/impl.py
+++ b/dbt/adapters/spark_livy/impl.py
@@ -441,7 +441,9 @@ class SparkAdapter(SQLAdapter):
     def cleanup_connections(self) -> None:
         self.connections.cleanup_all()
         logger.debug("cleanup_connections")
-        SparkConnectionManager.connection_manager.livy_global_session.delete_session()
+
+        for conn_mgr in SparkConnectionManager.connection_managers:
+            SparkConnectionManager.connection_managers[conn_mgr].livy_global_session.delete_session()
 
 # spark does something interesting with joins when both tables have the same
 # static values for the join condition and complains that the join condition is

--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -37,6 +37,102 @@ NUMBERS = DECIMALS + (int, float)
 
 DEFAULT_POLL_WAIT = 2
 
+class LivySession:
+    def __init__(self, connect_url, auth, headers, verify_ssl_certificate):
+        self.connect_url = connect_url
+        self.auth = auth
+        self.headers = headers
+        self.session_id = None
+        self.verify_ssl_certificate = verify_ssl_certificate
+
+    def __enter__(self):
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: Exception | None,
+        exc_tb: TracebackType | None,
+    ) -> bool:
+        self.delete_session()
+        return True
+
+    def create_session(self, data):
+        # Create sessions
+        response = None
+        try:
+            response = requests.post(
+                       self.connect_url + '/sessions', data=json.dumps(data),
+                       headers=self.headers,
+                       auth=self.auth,
+                       verify=self.verify_ssl_certificate
+            )
+            response.raise_for_status()
+        except requests.exceptions.ConnectionError as c_err:
+            print("Connection Error :", c_err)
+        except requests.exceptions.HTTPError as h_err:
+            print("Http Error: ", h_err)
+        except requests.exceptions.Timeout as t_err:
+            print("Timeout Error: ", t_err)
+        except requests.exceptions.RequestException as a_err:
+            print("Authorization Error: ", a_err)
+
+        if response is None:
+            raise Exception("Invalid response from livy server")
+
+        self.session_id = None
+        try:
+            self.session_id = str(response.json()['id'])
+        except requests.exceptions.JSONDecodeError as json_err:
+            raise Exception("Json decode error to get session_id") from json_err
+
+        # Wait for started state
+        while True:
+            res = requests.get(
+                self.connect_url + '/sessions/' + self.session_id + '/state',
+                headers=self.headers,
+                auth=self.auth,
+                verify=self.verify_ssl_certificate
+            ).json()
+
+            if res['state'] == 'idle':
+                break
+            if res['state'] == 'dead':
+                print("ERROR, cannot create a livy interactive session")
+                raise dbt.exceptions.FailedToConnectException(
+                        'failed to connect'
+                    )
+                return
+
+            time.sleep(DEFAULT_POLL_WAIT)
+
+        logger.debug(f"Creating new livy session: {self.session_id}")
+
+        return self.session_id
+
+    def delete_session(self):
+        logger.debug(f"Closing the connection and livy session: {self.session_id}")
+
+        # delete the session_id
+        _ = requests.delete(
+            self.connect_url + '/sessions/' + self.session_id,
+            headers=self.headers,
+            auth=self.auth,
+            verify=self.verify_ssl_certificate
+        )
+
+    def is_valid_session(self):
+        res = requests.get(
+                self.connect_url + '/sessions/' + self.session_id + '/state',
+                headers=self.headers,
+                auth=self.auth,
+                verify=self.verify_ssl_certificate
+            ).json()
+
+        return res['state'] == 'idle'
+
+
+# cursor object - wrapped for livy API
 class LivyCursor:
     """
     Mock a pyodbc cursor.
@@ -116,17 +212,7 @@ class LivyCursor:
         https://github.com/mkleehammer/pyodbc/wiki/Cursor#close
         """
         self._rows = None
-
-        # print("Closing the connection and livy session", self.session_id)
-
-        # delete the session_id 
-        _ = requests.delete(
-            self.connect_url + '/sessions/' + self.session_id, 
-            headers=self.headers, 
-            auth=self.auth, 
-            verify=self.verify_ssl_certificate
-        )
-
+        
     def _submitLivyCode(self, code):
         # Submit code
         data = {'code': code}
@@ -255,7 +341,6 @@ class LivyCursor:
 
         return row
 
-
 class LivyConnection:
     """
     Mock a pyodbc connection.
@@ -272,6 +357,8 @@ class LivyConnection:
         self.headers = headers
         self.session_params = session_params
         self.verify_ssl_certificate = verify_ssl_certificate
+
+        self._cursor = LivyCursor(self.connect_url, self.session_id, self.auth, self.headers, self.verify_ssl_certificate)
 
     def get_session_id(self):
         return self.session_id
@@ -294,10 +381,33 @@ class LivyConnection:
         out : Cursor
             The cursor.
         """
-        return LivyCursor(self.connect_url, self.session_id, self.auth, self.headers, self.verify_ssl_certificate)
+        return self._cursor
+
+    def close(self) -> None:
+        """
+        Close the connection.
+
+        Source
+        ------
+        https://github.com/mkleehammer/pyodbc/wiki/Cursor#close
+        """
+        logger.debug("Connection.close()")
+        self._cursor.close()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: Exception | None,
+        exc_tb: TracebackType | None,
+    ) -> bool:
+        self.close()
+        return True
 
 class LivyConnectionManager:
-    
+
+    def __init__(self):
+        self.livy_global_session = None
+
     def connect(self, connect_url, user, password, auth_type, session_params, verify_ssl_certificate):
         if auth_type and auth_type.lower() == "kerberos":
             logger.debug("Using Kerberos auth")
@@ -316,55 +426,23 @@ class LivyConnectionManager:
             'Content-Type': 'application/json'
         }
 
-        # Create sessions
-        response = None
-        try:
-            response = requests.post(
-                       connect_url + '/sessions', data=json.dumps(data), 
-                       headers=headers, 
-                       auth=auth, 
-                       verify=verify_ssl_certificate
-            )
-            response.raise_for_status()
-        except requests.exceptions.ConnectionError as c_err:
-            print("Connection Error :", c_err)
-        except requests.exceptions.HTTPError as h_err:
-            print("Http Error: ", h_err)
-        except requests.exceptions.Timeout as t_err:
-            print("Timeout Error: ", t_err)
-        except requests.exceptions.RequestException as a_err:
-            print("Authorization Error: ", a_err)
+        if (self.livy_global_session == None):
+            self.livy_global_session = LivySession(connect_url, auth, headers, verify_ssl_certificate)
+            self.livy_global_session.create_session(data)
+        elif not self.livy_global_session.is_valid_session():
+            self.livy_global_session.delete_session()
+            self.livy_global_session.create_session()
+        else:
+            logger.debug(f"Reusing session: {self.livy_global_session.session_id}")
 
-        if response is None:
-            raise Exception("Invalid response from livy server")
-
-        session_id = None
-        try:
-            session_id = str(response.json()['id'])
-        except requests.exceptions.JSONDecodeError as json_err:
-            raise Exception("Json decode error to get session_id") from json_err
-
-        # Wait for started state
-        while True:
-            res = requests.get(
-                connect_url + '/sessions/' + session_id + '/state', 
-                headers=headers, 
-                auth=auth,
-                verify=verify_ssl_certificate
-            ).json()
-
-            if res['state'] == 'idle':
-                break
-            if res['state'] == 'dead':
-                print("ERROR, cannot create a livy interactive session")
-                raise dbt.exceptions.FailedToConnectException(
-                        'failed to connect'
-                    ) 
-                return
-
-            time.sleep(DEFAULT_POLL_WAIT)
-
-        livyConnection = LivyConnection(connect_url, session_id, auth, headers, session_params, verify_ssl_certificate)
+        livyConnection = LivyConnection(
+                            connect_url,
+                            self.livy_global_session.session_id,
+                            auth,
+                            headers,
+                            session_params,
+                            verify_ssl_certificate
+                        )
 
         return livyConnection
 
@@ -383,8 +461,7 @@ class LivySessionConnectionWrapper(object):
         logger.debug("NotImplemented: cancel")
 
     def close(self):
-        if self._cursor:
-            self._cursor.close()
+        self.handle.close()
 
     def rollback(self, *args, **kwargs):
         logger.debug("NotImplemented: rollback")

--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -111,15 +111,18 @@ class LivySession:
         return self.session_id
 
     def delete_session(self):
-        logger.debug(f"Closing the connection and livy session: {self.session_id}")
+        logger.debug(f"Closing the livy session: {self.session_id}")
 
-        # delete the session_id
-        _ = requests.delete(
-            self.connect_url + '/sessions/' + self.session_id,
-            headers=self.headers,
-            auth=self.auth,
-            verify=self.verify_ssl_certificate
-        )
+        try:
+            # delete the session_id
+            _ = requests.delete(
+                self.connect_url + '/sessions/' + self.session_id,
+                headers=self.headers,
+                auth=self.auth,
+                verify=self.verify_ssl_certificate
+            )
+        except Exception as ex:
+            logger.error(f"Unable to close the livy session {self.session_id}, error: {ex}")
 
     def is_valid_session(self):
         res = requests.get(


### PR DESCRIPTION
Earlier behaviour: A new Livy session was created for each query being executed.
New behaviour: Only one Livy session per thread is generated, hence cutting down on the session creation overhead.

Tested this by doing a dbt run on sample project and noting that the execution completes correctly:
<pre>
(dev-dbt-spark-livy) ganesh.venkateshwara@ganesh dbtdemo % dbt debug -t cloudera-cia-spark_livy 
08:03:51  Running with dbt=1.3.1
dbt version: 1.3.1
python version: 3.9.12
python path: /Users/ganesh.venkateshwara/code/venv/dev/dev-dbt-spark-livy/bin/python
os info: macOS-12.6-arm64-arm-64bit
Using profiles.yml file at /Users/ganesh.venkateshwara/.dbt/profiles.yml
Using dbt_project.yml file at /Users/ganesh.venkateshwara/code/dbt-examples/dbtdemo/dbt_project.yml

Configuration:
  profiles.yml file [OK found and valid]
  dbt_project.yml file [OK found and valid]

Required dependencies:
 - git [OK found]

Connection:
  host: https://dbt-spark3-gateway.ciadev.cna2-sx9y.cloudera.site/dbt-spark3/cdp-proxy-api/livy_for_spark3/
  auth: None
  schema: dbtdemo_spark_livy
  Connection test: [OK connection ok]

All checks passed!
(dev-dbt-spark-livy) ganesh.venkateshwara@ganesh dbtdemo % dbt run -t cloudera-cia-spark_livy 
08:04:55  Running with dbt=1.3.1
08:04:55  Unable to do partial parsing because of a dbt version mismatch. Saved manifest version: 1.3.0. Current version: 1.3.1.
08:04:56  Found 3 models, 4 tests, 0 snapshots, 0 analyses, 329 macros, 0 operations, 2 seed files, 0 sources, 0 exposures, 0 metrics
08:04:56  
08:05:39  Concurrency: 1 threads (target='cloudera-cia-spark_livy')
08:05:39  
08:05:39  1 of 3 START sql table model dbtdemo_spark_livy.my_first_dbt_model ............. [RUN]
08:06:07  1 of 3 OK created sql table model dbtdemo_spark_livy.my_first_dbt_model ........ [OK in 27.44s]
08:06:07  2 of 3 START sql incremental model dbtdemo_spark_livy.my_incremental_model ..... [RUN]
08:06:16  2 of 3 OK created sql incremental model dbtdemo_spark_livy.my_incremental_model  [OK in 9.80s]
08:06:16  3 of 3 START sql table model dbtdemo_spark_livy.my_second_dbt_model ............ [RUN]
08:06:27  3 of 3 OK created sql table model dbtdemo_spark_livy.my_second_dbt_model ....... [OK in 11.10s]
08:06:29  
08:06:29  Finished running 2 table models, 1 incremental model in 0 hours 1 minutes and 32.85 seconds (92.85s).
08:06:31  
08:06:31  Completed successfully
08:06:31  
08:06:31  Done. PASS=3 WARN=0 ERROR=0 SKIP=0 TOTAL=3
</pre>
