### PR TITLE
check for spark version in macros that are only supported for spark3

### DIFF
--- a/dbt/adapters/spark_livy/impl.py
+++ b/dbt/adapters/spark_livy/impl.py
@@ -408,34 +408,6 @@ class SparkAdapter(SQLAdapter):
     def debug_query(self) -> None:
         self.execute("select 1 as id")
 
-        # query warehouse version
-        try:
-            sql_query = "select version()"
-            _, table = self.execute(sql_query, True, True)
-            version_object = []
-            json_funcs = [c.jsonify for c in table.column_types]
-
-            for row in table.rows:
-                values = tuple(json_funcs[i](d) for i, d in enumerate(row))
-                version_object.append(OrderedDict(zip(row.keys(), values)))
-
-            version_json = json.dumps(version_object)
-
-            payload = {
-                "event_type": "dbt_spark_livy_warehouse",
-                "warehouse_version": version_json,
-            }
-            tracker.track_usage(payload)
-        except Exception as ex:
-            logger.debug(
-                f"Warehouse version not available. Reason: {ex}"
-            )
-            payload = {
-                "event_type": "dbt_spark_livy_warehouse",
-                "warehouse_version": "NA",
-            }
-            tracker.track_usage(payload)
-
         self.connections.get_thread_connection().handle.close()
 
     def cleanup_connections(self) -> None:

--- a/dbt/include/spark_livy/macros/utils/array_append.sql
+++ b/dbt/include/spark_livy/macros/utils/array_append.sql
@@ -1,3 +1,7 @@
 {% macro spark_livy__array_append(array, new_element) -%}
-    {{ array_concat(array, array_construct([new_element])) }}
+    {% if env_var('DBT_SPARK_VERSION') == "2" %}
+        {{ exceptions.raise_compiler_error("Array functions need Spark 3") }}
+    {% else %}
+        {{ array_concat(array, array_construct([new_element])) }}
+    {% endif %}
 {%- endmacro %}

--- a/dbt/include/spark_livy/macros/utils/array_construct.sql
+++ b/dbt/include/spark_livy/macros/utils/array_construct.sql
@@ -1,3 +1,7 @@
 {% macro spark_livy__array_construct(inputs, data_type) -%}
-    array( {{ inputs|join(' , ') }} )
+    {% if env_var('DBT_SPARK_VERSION') == "2" %}
+        {{ exceptions.raise_compiler_error("Array functions need Spark 3") }}
+    {% else %}
+        array( {{ inputs|join(' , ') }} )
+    {% endif %}
 {%- endmacro %}

--- a/dbt/include/spark_livy/macros/utils/intersect.sql
+++ b/dbt/include/spark_livy/macros/utils/intersect.sql
@@ -1,7 +1,7 @@
-{% macro spark_livy__array_concat(array_1, array_2) -%}
+{% macro spark_livy___intersect() %}
     {% if env_var('DBT_SPARK_VERSION') == "2" %}
         {{ exceptions.raise_compiler_error("Array functions need Spark 3") }}
     {% else %}
-        concat({{ array_1 }}, {{ array_2 }})
+        intersect
     {% endif %}
-{%- endmacro %}
+{% endmacro %}


### PR DESCRIPTION
### Describe changes
* add function to get spark version
* move instrumentation code to remove duplicate calls for spark version 
* update macros that are not supported in older spark version 

### Testing

When using Spark 3:
<pre>
(dev-dbt-spark-livy) ganesh.venkateshwara@ganesh dbt-spark-livy % python -m pytest tests/functional/adapter/utils/test_utils.py -k 'TestIntersect' | tee test-intersect.log      
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-spark-livy, configfile: pytest.ini
collected 28 items / 27 deselected / 1 selected

tests/functional/adapter/utils/test_utils.py .                           [100%]

=============================== warnings summary ===============================
../../venv/dev/dev-dbt-spark-livy/lib/python3.9/site-packages/_pytest/config/__init__.py:1294
  /Users/ganesh.venkateshwara/code/venv/dev/dev-dbt-spark-livy/lib/python3.9/site-packages/_pytest/config/__init__.py:1294: PytestConfigWarning: Unknown config option: env_files

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 1 passed, 27 deselected, 1 warning in 1291.77s (0:21:31) ===========
</pre>

When using Spark 2, the following exception will be thrown:
<pre>
E       dbt.exceptions.CompilationException: Compilation Error in model actual (models/actual.sql)
E         Array functions need Spark 3
</pre>