### PR TITLE
address an issue with livy session creation

### DIFF
--- a/dbt/adapters/spark_livy/livysession.py
+++ b/dbt/adapters/spark_livy/livysession.py
@@ -434,7 +434,7 @@ class LivyConnectionManager:
             self.livy_global_session.create_session(data)
         elif not self.livy_global_session.is_valid_session():
             self.livy_global_session.delete_session()
-            self.livy_global_session.create_session()
+            self.livy_global_session.create_session(data)
         else:
             logger.debug(f"Reusing session: {self.livy_global_session.session_id}")
 


### PR DESCRIPTION
The call to create a livy session when session_id was invalidated did not have the default configuration data. This PR adds the default configuration when creating a livy session in this scenario.  