### PR TITLE
split dbt_adapter field in instrumentation to dbt_adapter_type and dbt_adapter_version

### DIFF
--- a/dbt/adapters/spark_livy/cloudera_tracking.py
+++ b/dbt/adapters/spark_livy/cloudera_tracking.py
@@ -65,7 +65,8 @@ def populate_platform_info(cred: Credentials, ver):
         "dbt_version"
     ] = dbt.version.get_installed_version().to_version_string(skip_matcher=True)
     # dbt adapter info e.g. impala-1.2.0
-    platform_info["dbt_adapter"] = f"{cred.type}-{ver.version}"
+    platform_info["dbt_adapter_type"] = f"{cred.type}"
+    platform_info["dbt_adapter_version"] = f"{ver.version}"
 
 def populate_dbt_deployment_env_info():
     """


### PR DESCRIPTION
split dbt_adapter field in instrumentation to dbt_adapter_type and dbt_adapter_version

Test Result:
{'data': '{"event_type": "dbt_spark_livy_open", "auth": "livy", "connection_state": "fail", "elapsed_time": "75.29", "connection_exception": "Invalid response from livy server", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "7f681b44-dbad-492c-a7a3-ff6d64ba01f3", "unique_host_hash": "279763963ad1afa5776991f84894d563", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "fd8899001f67bdf576b29a1d14f816a2", "python_version": "3.10.7", "system": "Darwin", "machine": "arm64", "platform": "macOS-13.0.1-arm64-arm-64bit", "dbt_version": "1.3.1", **"dbt_adapter_type": "spark_livy", "dbt_adapter_version": "1.3.0",** "dbt_deployment_env": {}, "project_name": "dbt_spark_livy_demo", "target_name": "cloudera-cia-spark-livy-dev", "no_of_threads": 2}'}