### PR TITLE
refactor cloudera_tracking: event type as enums, optional userkey, warehouse version fetch

### DIFF
--- a/dbt/adapters/spark_livy/cloudera_tracking.py
+++ b/dbt/adapters/spark_livy/cloudera_tracking.py
@@ -27,6 +27,15 @@ from dbt.adapters.base import Credentials
 from dbt.events import AdapterLogger
 from decouple import config
 
+# all event types
+class TrackingEventType:
+    DEBUG = "debug_and_fetch_permission"
+    OPEN = "open"
+    CLOSE = "close"
+    START_QUERY = "start_query"
+    END_QUERY = "end_query"
+    INCREMENTAL = "incremental"
+    MODEL_ACCESS = "model_access"
 
 # global logger
 logger = AdapterLogger("Tracker")
@@ -45,6 +54,9 @@ profile_info = {}
 
 # Json object to store dbt deployment environment variables
 dbt_deployment_env_info = {}
+
+# Json object for warehouse information
+warehouse_info = { "warehouse_version": { "version": "NA", "build": "NA" } }
 
 def populate_platform_info(cred: Credentials, ver):
     """
@@ -65,7 +77,8 @@ def populate_platform_info(cred: Credentials, ver):
         "dbt_version"
     ] = dbt.version.get_installed_version().to_version_string(skip_matcher=True)
     # dbt adapter info e.g. impala-1.2.0
-    platform_info["dbt_adapter"] = f"{cred.type}-{ver.version}"
+    platform_info["dbt_adapter_type"] = f"{cred.type}"
+    platform_info["dbt_adapter_version"] = f"{ver.version}"
 
 def populate_dbt_deployment_env_info():
     """
@@ -74,9 +87,9 @@ def populate_dbt_deployment_env_info():
     default_value = "{}"  # if environment variables doesn't exist add empty json as default
     dbt_deployment_env_info["dbt_deployment_env"] = json.loads(os.environ.get('DBT_DEPLOYMENT_ENV', default_value))
 
-def populate_unique_ids(cred: Credentials):
+def populate_unique_ids(cred: Credentials, userkey="username"):
     host = str(cred.host).encode()
-    user = str(cred.user).encode()
+    user = str(getattr(cred, userkey)).encode()
     timestamp = str(time.time()).encode()
 
     # dbt invocation id
@@ -92,7 +105,6 @@ def populate_unique_ids(cred: Credentials):
     # hashed session
     unique_ids["unique_session_hash"] = hashlib.md5(host + user + timestamp).hexdigest()
 
-
 def generate_profile_info(self):
     if not profile_info:
         # name of dbt project in profiles
@@ -102,6 +114,9 @@ def generate_profile_info(self):
         # number of threads in profiles
         profile_info["no_of_threads"] = self.profile.threads
 
+def populate_warehouse_info(w_info):
+    warehouse_info["warehouse_version"]["version"] = w_info["version"]
+    warehouse_info["warehouse_version"]["build"] = w_info["build"]
 
 def _merge_keys(source_dict, dest_dict):
     for key, value in source_dict.items():
@@ -187,6 +202,7 @@ def track_usage(tracking_payload):
     tracking_payload = _merge_keys(platform_info, tracking_payload)
     tracking_payload = _merge_keys(dbt_deployment_env_info, tracking_payload)
     tracking_payload = _merge_keys(profile_info, tracking_payload)
+    tracking_payload = _merge_keys(warehouse_info, tracking_payload)
 
     # form the tracking data
     tracking_data = {"data": json.dumps(tracking_payload)}
@@ -213,6 +229,8 @@ def track_usage(tracking_payload):
             "x-datacoral-passthrough": "true",
         }
 
+        logger.debug(f"Sending Event {data}")
+
         data = json.dumps([data])
 
         res = None
@@ -227,8 +245,6 @@ def track_usage(tracking_payload):
             usage_tracking = False
 
         return res
-
-    logger.debug(f"Sending Event {tracking_data}")
 
     # call the tracking function in a Thread
     the_track_thread = threading.Thread(

--- a/dbt/adapters/spark_livy/relation.py
+++ b/dbt/adapters/spark_livy/relation.py
@@ -36,7 +36,7 @@ class SparkRelation(BaseRelation):
         if self.type:
             tracker.track_usage(
                 {
-                    "event_type": "dbt_spark_livy_model_access",
+                    "event_type": tracker.TrackingEventType.MODEL_ACCESS,
                     "model_name": self.render(),
                     "model_type": self.type,
                     "incremental_strategy": "",
@@ -55,7 +55,7 @@ class SparkRelation(BaseRelation):
         if self.type:
             tracker.track_usage(
                 {
-                    "event_type": "dbt_spark_livy_new_incremental",
+                    "event_type": tracker.TrackingEventType.INCREMENTAL,
                     "model_name": self.render(),
                     "model_type": self.type,
                     "incremental_strategy": incremental_strategy,


### PR DESCRIPTION
## Describe your changes
* modify populate_unique_ids to provide optional userkey
* refactor warehouse key, add event type enums
* use the refactored tracking lib: event type, warehouse version 

## Testing:
Using dbt debug, a sample tacking payload in dbt.logs:
<pre>
[0m12:21:07.490214 [debug] [Thread-25 ]: Tracker adapter: Sending Event {'data': '{"event_type": "start_query", "profile_name": "dbtdemo", "app": "dbt", "dbt_version": "1.3.1", "target_name": "cloudera-cia-spark_livy", "node_id": "model.dbtdemo.my_first_dbt_model", "sql_type": "create table", "auth": "N/A", "connection_state": "N/A", "elapsed_time": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "id": "7d9a7099-02a7-45da-b9cf-d179c4b00d94", "unique_host_hash": "279763963ad1afa5776991f84894d563", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "0a4a0998b68a35d56a3207726ad7c335", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-13.0.1-arm64-arm-64bit", "dbt_adapter_type": "spark_livy", "dbt_adapter_version": "1.3.0", "dbt_deployment_env": {}, "project_name": "dbtdemo", "no_of_threads": 4, "warehouse_version": {"version": "3", "build": "3.2.1 f38f605165f50b0d9e887e279c350728b839915d"}}'}
</pre>