### PR TITLE
fix: coerce some types from query result set

### DIFF
--- a/tests/unit/test_livysession.py
+++ b/tests/unit/test_livysession.py
@@ -1,0 +1,18 @@
+import unittest
+
+from dbt.adapters.spark_livy.livysession import LivyCursor
+import datetime as dt
+
+
+class TestLivySession(unittest.TestCase):
+    def test_coerce_some_column_types_from_response_rows(self):
+        schema = [
+            {'name': 'created_at', 'type': 'timestamp', 'nullable': True, 'metadata': {}},
+            {'name': 'literal_str', 'type': 'string', 'nullable': False, 'metadata': {}},
+            {'name': 'number', 'type': 'decimal', 'nullable': False, 'metadata': {}}
+        ]
+        res_rows = [['2023-02-06T17:03:30Z', 'literal string', '12'], ['2023-02-16T09:20:24Z', 'literal a', '20']]
+        rows = LivyCursor._coerce_some_primitive_types(schema, res_rows)
+        expected_rows = [[dt.datetime(2023, 2, 6, 17, 3, 30), 'literal string', '12'],
+                         [dt.datetime(2023, 2, 16, 9, 20, 24), 'literal a', '20']]
+        self.assertEqual(rows, expected_rows)


### PR DESCRIPTION
### Description

when running `dbt source freshness` the result could not be coerced to timestamp from response strings

```sh
^[[0m06:33:28.268707 [error] [MainThread]: ^[[33mDatabase Error in source bnpl_transaction_get_offers_stag_schema_id_163 (models/bnpl/sources.yml)^[[0m^[[0m06:33:28.268883 [error]
[MainThread]:   Expected a timestamp value when querying field 'ingestion_time' of table bnpl.bnpl_transaction_get_offers_stag_schema_id_163 but received value of type 'str' instead
```

noticed that from v0.20 `dbt-core` has been updated to prevent using agate table coercion from SQL adapter query result (https://github.com/dbt-labs/dbt-core/pull/3499)

this PR aims to support the coercion for timestamp type from livy query result set

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
